### PR TITLE
Add host to hostfile

### DIFF
--- a/automated_builder/roles/common/tasks/bootstrap_vps.yml
+++ b/automated_builder/roles/common/tasks/bootstrap_vps.yml
@@ -33,3 +33,12 @@
         user: ansible
         commands: ALL
         nopassword: true
+
+    - name: Add host to hosts file
+      lineinfile:
+        path: /etc/hosts
+        search_string: '127.0.0.1'
+        line: '127.0.0.1 localhost host'
+        owner: root
+        group: root
+        mode: '0644'


### PR DESCRIPTION
### Description

Dynamically add `127.0.0.1 localhost host` to `/etc/hosts/` in order to satisfy derivative-maker build scripts