### PR TITLE
Ci cloud init bug

### DIFF
--- a/.github/workflows/run_automated_builder.yml
+++ b/.github/workflows/run_automated_builder.yml
@@ -50,7 +50,7 @@ jobs:
           name: logs
           path: ./automated_builder/logs/
 
-      - name: Teardown build
-        if: always()
-        run: |
-          ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD
+      # - name: Teardown build
+      #   if: always()
+      #   run: |
+      #     ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD

--- a/.github/workflows/run_automated_builder.yml
+++ b/.github/workflows/run_automated_builder.yml
@@ -50,7 +50,7 @@ jobs:
           name: logs
           path: ./automated_builder/logs/
 
-      # - name: Teardown build
-      #   if: always()
-      #   run: |
-      #     ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD
+      - name: Teardown build
+        if: always()
+        run: |
+          ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD

--- a/automated_builder/roles/common/tasks/install_dependencies.yml
+++ b/automated_builder/roles/common/tasks/install_dependencies.yml
@@ -2,9 +2,15 @@
 - name: Install dependencies
   become: true
   block:
-    - name: Wait for cloud-init / user-data to finish
-      command: cloud-init status --wait
-      changed_when: false
+    - name: Check droplet status
+      community.digitalocean.digital_ocean_droplet_info:
+        oauth_token: "{{ DO_API_TOKEN }}"
+        name: automated-builder-vps
+      register: droplet_facts
+
+    - name: Debug droplet_facts
+      debug:
+        var: droplet_facts
 
     - name: Install apt packages
       apt:

--- a/automated_builder/roles/common/tasks/install_dependencies.yml
+++ b/automated_builder/roles/common/tasks/install_dependencies.yml
@@ -6,7 +6,7 @@
     oauth_token: "{{ DO_API_TOKEN }}"
     name: automated-builder-vps
   register: droplet_facts
-  until: droplet_facts.data.status == "active"
+  until: droplet_facts.data[0].status == "active"
 
 - name: Install apt packages
   become: true

--- a/automated_builder/roles/common/tasks/install_dependencies.yml
+++ b/automated_builder/roles/common/tasks/install_dependencies.yml
@@ -1,29 +1,26 @@
 ---
-- name: Install dependencies
+- name: Check droplet status
+  retries: 10
+  delay: 20
+  community.digitalocean.digital_ocean_droplet_info:
+    oauth_token: "{{ DO_API_TOKEN }}"
+    name: automated-builder-vps
+  register: droplet_facts
+  until: droplet_facts.data.status == "active"
+
+- name: Install apt packages
   become: true
-  block:
-    - name: Check droplet status
-      community.digitalocean.digital_ocean_droplet_info:
-        oauth_token: "{{ DO_API_TOKEN }}"
-        name: automated-builder-vps
-      register: droplet_facts
-
-    - name: Debug droplet_facts
-      debug:
-        var: droplet_facts
-
-    - name: Install apt packages
-      apt:
-        pkg:
-          - git
-          - time
-          - curl
-          - lsof
-          - apt-cacher-ng
-          - lsb-release
-          - fakeroot
-          - dpkg-dev
-          - fasttrack-archive-keyring
-          - dnsutils
-          - software-properties-common
-        update_cache: true
+  apt:
+    pkg:
+      - git
+      - time
+      - curl
+      - lsof
+      - apt-cacher-ng
+      - lsb-release
+      - fakeroot
+      - dpkg-dev
+      - fasttrack-archive-keyring
+      - dnsutils
+      - software-properties-common
+    update_cache: true


### PR DESCRIPTION
## Description

`cloud-init` was failing for some dumb reason, but its only purpose was to ensure a droplet was online before calling apt commands. This PR checks if the droplet is online via the DigitalOcean API instead, and should be more resilient.