### PR TITLE
Add cloud init status wait

### DIFF
--- a/automated_builder/roles/common/tasks/install_dependencies.yml
+++ b/automated_builder/roles/common/tasks/install_dependencies.yml
@@ -8,6 +8,10 @@
   register: droplet_facts
   until: droplet_facts.data[0].status == "active"
 
+- name: Wait for cloud-init / user-data to finish
+  command: cloud-init status --wait
+  changed_when: false
+
 - name: Install apt packages
   become: true
   apt:


### PR DESCRIPTION
## Description

Sometimes the VM hangs because cloud init isn't finished. This should fix it