### PR TITLE
Get Working Builds

### DIFF
--- a/.github/workflows/run_automated_builder.yml
+++ b/.github/workflows/run_automated_builder.yml
@@ -54,7 +54,7 @@ jobs:
           name: logs
           path: ./automated_builder/logs/
 
-      - name: Teardown build
-        if: always()
-        run: |
-          ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD
+      # - name: Teardown build
+      #   if: always()
+      #   run: |
+      #     ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD

--- a/.github/workflows/run_automated_builder.yml
+++ b/.github/workflows/run_automated_builder.yml
@@ -54,7 +54,7 @@ jobs:
           name: logs
           path: ./automated_builder/logs/
 
-      # - name: Teardown build
-      #   if: always()
-      #   run: |
-      #     ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD
+      - name: Teardown build
+        if: always()
+        run: |
+          ./automated_builder/scripts/teardown_build.sh $ANSIBLE_VAULT_PASSWORD

--- a/automated_builder/roles/common/templates/install_source.sh
+++ b/automated_builder/roles/common/templates/install_source.sh
@@ -9,25 +9,25 @@ VERSION_TAG="$3"
 GITHUB_EVENT_NAME="$4"
 
 main() {
-  echo "$0: START"
-  echo "Running source code installation script..."
+  determine_event
+  clean_old_source
+  install_source_code
+  checkout_code
+}
+
+determine_event() {
+  echo "Determining source code ref"
   echo "REPO_URL: $REPO_URL"
   echo "COMMIT_BRANCH: $COMMIT_BRANCH"
   echo "VERSION_TAG: $VERSION_TAG"
   echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
 
-  if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-      skip_tag="true"
-      echo "Detected pull request. VERSION_TAG set to empty."
+  if [[ "${GITHUB_EVENT_NAME}" = "pull_request" ]]; then
+      SKIP_TAG=1
+      echo "Detected pull request. SKIP_TAG set to true"
   else
-      echo "Regular branch or tag push. Using provided VERSION_TAG: $VERSION_TAG"
+      echo "Tag or commit push. Using provided ref: $VERSION_TAG"
   fi
-
-  clean_old_source
-  install_source_code
-  checkout_code
-
-  echo "$0: END"
 }
 
 clean_old_source() {

--- a/automated_builder/roles/common/templates/install_source.sh
+++ b/automated_builder/roles/common/templates/install_source.sh
@@ -14,16 +14,14 @@ main() {
   echo "REPO_URL: $REPO_URL"
   echo "COMMIT_BRANCH: $COMMIT_BRANCH"
   echo "VERSION_TAG: $VERSION_TAG"
+  echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
 
   if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-      VERSION_TAG=""
+      skip_tag="true"
       echo "Detected pull request. VERSION_TAG set to empty."
   else
       echo "Regular branch or tag push. Using provided VERSION_TAG: $VERSION_TAG"
   fi
-
-  ## Debugging.
-  env
 
   clean_old_source
   install_source_code
@@ -51,7 +49,7 @@ install_source_code() {
 }
 
 checkout_code(){
-  if [ -z "$VERSION_TAG" ]; then
+  if [ -z "$skip_tag" ]; then
     git checkout "$COMMIT_BRANCH"
   else
     git checkout "$VERSION_TAG"

--- a/automated_builder/roles/gui-build/templates/build_vms_from_tag.sh
+++ b/automated_builder/roles/gui-build/templates/build_vms_from_tag.sh
@@ -7,18 +7,12 @@ true "$0: START"
 
 export CI=true
 
-## Debugging.
-#export dist_build_no_unset_xtrace=true
-
 main() {
   build_command "$@" >> /home/ansible/build.log 2>&1
 }
 
 build_command() {
-  debug_args_maybe=()
-  #debug_args_maybe+=(--remote-derivative-packages true)
-
-  /home/ansible/derivative-maker/help-steps/dm-build-official "${debug_args_maybe[@]}" "$@"
+  /home/ansible/derivative-maker/help-steps/dm-build-official
 }
 
 main "$@"

--- a/automated_builder/roles/headless-build/tasks/install_source.yml
+++ b/automated_builder/roles/headless-build/tasks/install_source.yml
@@ -6,4 +6,4 @@
     mode: 0744
 
 - name: Run install_source script for commit
-  shell: "/home/ansible/install_source.sh {{ GIT_REPO }} {{ REF_NAME }} {{ GITHUB_EVENT_NAME }} > /home/ansible/install_source.log 2>&1"
+  shell: "/home/ansible/install_source.sh {{ GIT_REPO }} {{ REF_NAME }} {{ REF_NAME }} {{ GITHUB_EVENT_NAME }} > /home/ansible/install_source.log 2>&1"

--- a/automated_builder/roles/headless-build/templates/build_vms_from_commit.sh
+++ b/automated_builder/roles/headless-build/templates/build_vms_from_commit.sh
@@ -1,8 +1,23 @@
+
 #!/bin/bash
 
 set -x
 set -e
 
-/home/ansible/build_vms_from_tag.sh \
-  --allow-untagged true \
-  --remote-derivative-packages true
+true "$0: START"
+
+export CI=true
+
+main() {
+  build_command "$@" >> /home/ansible/build.log 2>&1
+}
+
+build_command() {
+  /home/ansible/derivative-maker/help-steps/dm-build-official \
+    --allow-untagged true \
+    --remote-derivative-packages true
+}
+
+main "$@"
+
+true "$0: END"


### PR DESCRIPTION
@adrelanos this runs builds now for tags and commits. I seperated the tag builds and the commit builds with different scripts.

You can find them in the templates folder for the headless and non-headless roles.

The build is failing now for things outside the scope of CI. But CI is back