### PR TITLE
Minor fixes

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -47,7 +47,9 @@ volume_check "${CACHER_VOLUME}" '101:102' '770'
 
 sudo -- modprobe -a loop dm_mod
 
-sudo -- docker \
+sudo \
+  -- \
+    docker \
       run \
       --name derivative-maker-docker \
       --interactive \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -6,6 +6,7 @@
 set -x
 set -e
 
+USER="user"
 BUILDER_VOLUME="$(dirname -- "$PWD")"
 CACHER_VOLUME="$HOME/apt_cacher_mnt"
 IMG="derivative-maker/derivative-maker-docker"
@@ -33,10 +34,6 @@ while true; do
       shift
       break
       ;;
-    -*)
-      printf '%s\n' "$0: ERROR: unknown option: $1" >&2
-      exit 1
-      ;;
     *)
       break
       ;;
@@ -50,11 +47,7 @@ volume_check "${CACHER_VOLUME}" '101:102' '770'
 
 sudo -- modprobe -a loop dm_mod
 
-sudo \
-  --preserve-env \
-  -u "${USER}" \
-  -- \
-    docker \
+sudo -- docker \
       run \
       --name derivative-maker-docker \
       --interactive \
@@ -67,4 +60,8 @@ sudo \
       --env 'DERIVATIVE_APT_REPOSITORY_OPTS=' \
       --volume "${BUILDER_VOLUME}:/home/user/derivative-maker" \
       --volume "${CACHER_VOLUME}:/var/cache/apt-cacher-ng" "${IMG}" \
-      "${@}"
+      sudo \
+      --preserve-env \
+      -u "${USER}" \
+      -- \
+      /usr/bin/start_build.sh "${@}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -66,4 +66,4 @@ sudo \
       --preserve-env \
       -u "${USER}" \
       -- \
-      /usr/bin/start_build.sh "${@}"
+      "${@}"

--- a/docker/start_build.sh
+++ b/docker/start_build.sh
@@ -27,7 +27,6 @@ cd -- "${SOURCE_DIR}"
     git describe
     git verify-tag "${TAG}"
   }
-  git verify-commit "${TAG}^{commit}"
   git status
 } 2>&1 | tee -a -- "${GIT_LOG}"
 


### PR DESCRIPTION
Did some quick testing.

`run.sh`
* `-*)` matches regular `--` options like `--flavor` since not previously parsed -> removing and letting derivative-maker `parse-cmd` handle wrong options
* `USER` must be defined here, because `run.sh` executed on host (mixup before)
* first `sudo`  for docker privileges
* second `sudo` to execute `start_build.sh` as user (Previously used `su` for `--session-command` option)

`start_build.sh`
* removing   git verify-commit because obsolete and requires `gpg` before derivative-maker